### PR TITLE
Add Tag `only`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Example: `login.data.yaml`
 			* [$file](#basicAuthFile)
 		* [save](#save)
 		* [print](#print)
+		* [only](#only)
 		* [expect](#expect)
 			* [json](#expect)
 			* [headers](#expect)
@@ -225,6 +226,13 @@ module.exports = {
 If we want to print the response or error then we can do that by using `print` tag. Example:
 ```sh
 print: 1
+```
+<br />
+
+**<a name='only'>`only:`</a>**
+If we want to run only a subset of tests by using `only` tag. Example:
+```sh
+only: true
 ```
 <br />
 

--- a/src/apiCall.js
+++ b/src/apiCall.js
@@ -31,7 +31,8 @@ module.exports = function apiCall(file, apiPort) {
   }
 
   config.apiCalls.swagger.forEach(req => {
-    it(req.name || req.call, async function () {
+    const itMethod = req.only ? it.only : it;
+    itMethod(req.name || req.call, async function () {
       this.timeout(apiPort.get('TIMEOUT'))
 
       if (!operationIds[req.call]) {

--- a/src/apiPort.js
+++ b/src/apiPort.js
@@ -45,17 +45,20 @@ class ApiPort {
     apis.servers[0] = { url: this.get('API_SERVER_URL') }
 
     for (const path of Object.keys(apis.paths)) {
-      let params = apis.paths[path].parameters || []
+      const params = apis.paths[path].parameters || []
       for (const action of Object.keys(apis.paths[path])) {
-        if (apis.paths[path][action].operationId) {
-          operations[apis.paths[path][action].operationId] = apis.paths[path][action]
-          operations[apis.paths[path][action].operationId].path = path
-          operations[apis.paths[path][action].operationId].method = action
-          operations[apis.paths[path][action].operationId].parameters = _.unionBy(
-            apis.paths[path][action].parameters,
+        const actionObj = apis.paths[path][action];
+        const operationId = actionObj.operationId
+        if (operationId) {
+          const operation = apis.paths[path][action]
+          operation.path = path
+          operation.method = action
+          operation.parameters = _.unionBy(
+            actionObj.parameters,
             params,
             'name'
           )
+          operations[actionObj.operationId] = operation;
         }
       }
     }

--- a/src/mocha.js
+++ b/src/mocha.js
@@ -17,7 +17,8 @@ if (apiPort.get('API_TESTS_PATH')) {
             if (filePath.match(/spec\.yaml$/)) {
                 const config = YAML.load(filePath)
                 describe(filePath, function() {
-                    describe((config.apiCalls || {}).name || 'unnamed', function test() {
+                    const describeMethod = config.only ? describe.only : describe;
+                    describeMethod((config.apiCalls || {}).name || 'unnamed', function test() {
                         if (!(config.apiCalls || {}).name) {
                             it('suite should have a name', function() {
                                 assert.fail()


### PR DESCRIPTION
Fixes: https://github.com/testbetter/openapitest/issues/3

Use case : 

User wanna run one or more tests instead of the all test suite