### PR TITLE
Add support to deep key use variables

### DIFF
--- a/src/apiPort.js
+++ b/src/apiPort.js
@@ -156,9 +156,13 @@ class ApiPort {
 
   resolveObject(obj = {}) {
     for (const key of Object.keys(obj)) {
-      obj[key] = this.resolve(obj[key])
+      const value = obj[key];
+      if (_.isObject(value)) {
+       obj[key] = this.resolveObject(value)
+      } else {
+       obj[key] = this.resolve(value)
+      }
     }
-
     return obj
   }
 


### PR DESCRIPTION
The variable resolver would not resolve deep keys using variable.

Previously :

```yaml
...
 data:
     name: ${name} #Would evaluate
...
```

```yaml
...
 data:
        user:
          _id: '5c7800ec69733f6bcef07a16'
          firstName:  ${name} #Would not evaluate
.... 
``` 

Now :

```yaml
...
 data:
     name: ${name} #Would evaluate
...
```

```yaml
...
 data:
        user:
          _id: '5c7800ec69733f6bcef07a16'
          firstName:  ${name} # Will evaluate
           invitee:
               firstName:  ${name} # Will evaluate too
``` 