### PR TITLE
[BugFix] Fix global config load for windows, move load file to util add unit 

### DIFF
--- a/fixtures/fixture.javascript.js
+++ b/fixtures/fixture.javascript.js
@@ -1,0 +1,3 @@
+module.exports = {
+  data: 1,
+}

--- a/specs/util.spec.js
+++ b/specs/util.spec.js
@@ -1,6 +1,7 @@
 const {
   expect,
 } = require('chai')
+const path = require('path')
 const util = require('../src/util.js')
 
 describe('util', () => {
@@ -44,6 +45,31 @@ describe('util', () => {
       expect(data).to.deep.equal({
         test: 'This is a test',
         value: 123,
+      })
+    })
+  })
+
+  describe('loadFile', () => {
+    it('Should resolve the files and parse yaml into to an object with extention missing', () => {
+      const data = util.loadFile('./fixtures/fixture.data')
+      expect(data).to.deep.equal({
+        test: 'This is a test',
+        value: 123,
+      })
+    })
+
+    it('Should resolve the files and parse yaml into to an object if the extentions is present', () => {
+      const data = util.loadFile('./fixtures/fixture.data.yaml')
+      expect(data).to.deep.equal({
+        test: 'This is a test',
+        value: 123,
+      })
+    })
+
+    it('Should resolve js files', () => {
+      const data = util.loadFile(path.resolve('./fixtures/fixture.javascript'))
+      expect(data).to.deep.equal({
+        data: 1,
       })
     })
   })

--- a/specs/util.spec.js
+++ b/specs/util.spec.js
@@ -72,5 +72,9 @@ describe('util', () => {
         data: 1,
       })
     })
+
+    it('should thrown an error if the file does not exists', () => {
+      expect(() => util.loadFile('./there-no-this-file')).to.throw('Could not load the file: "./there-no-this-file". One of the next files must exists: ./there-no-this-file,./there-no-this-file.js,./there-no-this-file.yaml,./there-no-this-file.yml');
+    });
   })
 })

--- a/src/apiPort.js
+++ b/src/apiPort.js
@@ -235,10 +235,15 @@ class ApiPort {
       for (const testDataPath of lookIn) {
         if (testDataPath) {
           const filePath = `${testDataPath}/${fileName}.data`
-          const fileData = loadFile(filePath)
-          if (fileData) {
-            this.apiPort.$file[fileName] = fileData
-            break
+          try {
+            const fileData = loadFile(filePath)
+            if (fileData) {
+              this.apiPort.$file[fileName] = fileData
+              break
+            }
+          } catch (e) {
+            delete this.apiPort.$file[fileName]
+            // Ignored here if not found will re-throw the error in the end of this loop
           }
         }
       }

--- a/src/apiPort.js
+++ b/src/apiPort.js
@@ -4,7 +4,7 @@ const expect = require('expect.js')
 const fs = require('fs')
 const path = require('path')
 const klawSync = require('klaw-sync')
-const { loadYamlFile } = require('./util.js')
+const { loadFile } = require('./util.js')
 
 const currentDir = process.cwd()
 
@@ -18,16 +18,6 @@ function getLocalDir(dir, required = true) {
     return undefined
   }
   return localDir
-}
-
-function loadFile(filePath) {
-  let fileData;
-  if (fs.existsSync(`${filePath}.js`)) {
-    fileData = require(`${filePath}.js`) // eslint-disable-line import/no-dynamic-require, global-require
-  } if (fs.existsSync(`${filePath}.yaml`)) {
-    fileData = loadYamlFile(`${filePath}.yaml`)
-  }
-  return fileData;
 }
 
 function parseOpValue(expectationValue) {

--- a/src/util.js
+++ b/src/util.js
@@ -32,7 +32,20 @@ function loadYamlFile(filePath) {
 }
 
 
+function loadFile(filePath) {
+  let fileData;
+  if (fs.existsSync(`${filePath}.js`)) {
+    fileData = require(`${filePath}.js`) // eslint-disable-line import/no-dynamic-require, global-require
+  } else if (fs.existsSync(`${filePath}.yaml`)) {
+    fileData = loadYamlFile(`${filePath}.yaml`)
+  } else if (fs.existsSync(filePath)) {
+    fileData = loadYamlFile(filePath)
+  }
+  return fileData;
+}
+
 module.exports = {
   loadYamlFile,
   evaluateData,
+  loadFile,
 }

--- a/src/util.js
+++ b/src/util.js
@@ -39,7 +39,7 @@ function loadFile(fileToLoad) {
 
   if (filePath) {
     let fileData;
-    if (endsWith(filePath, 'js')) {
+    if (endsWith(filePath, '.js')) {
       fileData = require(filePath) // eslint-disable-line import/no-dynamic-require, global-require
     } else {
       fileData = loadYamlFile(filePath)

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const YAML = require('js-yaml')
 const {
-  isFunction, includes, set, isObject,
+  isFunction, includes, set, isObject, find, endsWith,
 } = require('lodash')
 
 const isObj = value => isObject(value) && !isFunction(value)
@@ -32,16 +32,22 @@ function loadYamlFile(filePath) {
 }
 
 
-function loadFile(filePath) {
-  let fileData;
-  if (fs.existsSync(`${filePath}.js`)) {
-    fileData = require(`${filePath}.js`) // eslint-disable-line import/no-dynamic-require, global-require
-  } else if (fs.existsSync(`${filePath}.yaml`)) {
-    fileData = loadYamlFile(`${filePath}.yaml`)
-  } else if (fs.existsSync(filePath)) {
-    fileData = loadYamlFile(filePath)
+function loadFile(fileToLoad) {
+  const candidateFileNames = [fileToLoad, `${fileToLoad}.js`, `${fileToLoad}.yaml`, `${fileToLoad}.yml`];
+
+  const filePath = find(candidateFileNames, fs.existsSync)
+
+  if (filePath) {
+    let fileData;
+    if (endsWith(filePath, 'js')) {
+      fileData = require(filePath) // eslint-disable-line import/no-dynamic-require, global-require
+    } else {
+      fileData = loadYamlFile(filePath)
+    }
+    return fileData;
   }
-  return fileData;
+  throw Error(`Could not load the file: "${fileToLoad}".`
+    + ` One of the next files must exists: ${candidateFileNames.join(',')}`)
 }
 
 module.exports = {


### PR DESCRIPTION
+tests to load file method.
No documentation change is needed this is just a bug fix.
The fix was in https://github.com/testbetter/openapitest/compare/master...mateusfreira:fix-config-load-in-windowns?expand=1#diff-34a6d62af0cf0b784f8444529f3130efR41 where we also need to check for the full path before loading