### PR TITLE
Add Faker.js to generate more realistic data in the integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Openapitest Framework
+
 The purpose of this openapitest framework is to simplify authoring, organizing, executing, and reporting result of API tests using API specification. It runs on node.js and distributed via npm. Add this module to your node.js project as a development dependency and start writing API or Integration tests using YAML language.
 
 
-[![Build Status](https://travis-ci.org/mateusfreira/openapitest.svg?branch=master)](https://travis-ci.org/mateusfreira/openapitest)
+[![Build Status](https://travis-ci.org/testbetter/openapitest.svg?branch=master)](https://travis-ci.org/testbetter/openapitest)
 
 ### Installation
 ----

--- a/README.md
+++ b/README.md
@@ -501,3 +501,42 @@ tests:
 
 ```
 <br /><br />
+
+## Fake data
+Sometime you may want to randomize the tests to create more realistic Test Scenarios. For that, we provide an   Out of
+the box [Faker.js API](http://marak.github.io/faker.js/index.html). 
+
+Faker is a massive amount of fake data generator.
+All you need to do is to add in any field the type `$faker ["$faker.api.you.want", "$scope"]`, and it will be replaced by the randomized value. Next, we are going to present some examples, if you need the complete documentation, please read [Faker.js
+docs](http://marak.github.io/faker.js/index.html).
+
+```yaml
+apiCalls:
+  name: login to the system
+  swagger:
+  - name: Login fail - try with wrong password
+    call: post_users_login
+    data:
+      email: !faker ["internet.email"]
+      password: !faker ["internet.password"]
+    query:
+      allow-redirect: 0
+    expect:
+      status: 403
+      error: Forbidden
+```
+
+In the example above, the fields, `email` and `password` will be diferent for each test execution, onde Faker.js will
+generate a diferent valid email for each time it runs.
+
+## Fake data scope
+
+
+There are tree scopes for the `!faker` calls, they are `global`, `file` or `test`. If you do not provide a scope, the
+framework will use `global` as default. 
+
+* Global scope will be evaluated once the file is loaded, and therefore will not change in the all test execution
+* File scope will be evaluated for before start the test, so it will have a different value for each test execution
+* Test scope will be evaluated for before start the `it` execution, so it will have a different value for each spec
+
+<br /><br />

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Sometime you may want to randomize the tests to create more realistic Test Scena
 the box [Faker.js API](http://marak.github.io/faker.js/index.html). 
 
 Faker is a massive amount of fake data generator.
-All you need to do is to add in any field the type `$faker ["$faker.api.you.want", "$scope"]`, and it will be replaced by the randomized value. Next, we are going to present some examples, if you need the complete documentation, please read [Faker.js
+All you need to do is to add in any field the type `!faker ["faker.api.you.want", "scope"]`, and it will be replaced by the randomized value. Next, we are going to present some examples, if you need the complete documentation, please read [Faker.js
 docs](http://marak.github.io/faker.js/index.html).
 
 ```yaml

--- a/fixtures/fixture-with-faker-invalid-scope.data.yaml
+++ b/fixtures/fixture-with-faker-invalid-scope.data.yaml
@@ -1,0 +1,2 @@
+test: This is a test
+name: !faker ["name.lastName", "wrong-scope"]

--- a/fixtures/fixture-with-faker-invalid.data.yaml
+++ b/fixtures/fixture-with-faker-invalid.data.yaml
@@ -1,0 +1,2 @@
+test: This is a test
+name: !faker

--- a/fixtures/fixture-with-faker.data.yaml
+++ b/fixtures/fixture-with-faker.data.yaml
@@ -3,5 +3,5 @@ name: !faker ["name.firstName", "global"]
 number: !faker ["random.number"]
 some: 
     anotherOne: 
-        deepDeepValue: !faker ["name.lastName"]
+            deepDeepValue: !faker ["name.lastName"]
 nameInFile: !faker ["name.firstName", "file"]

--- a/fixtures/fixture-with-faker.data.yaml
+++ b/fixtures/fixture-with-faker.data.yaml
@@ -4,4 +4,4 @@ number: !faker ["random.number"]
 some: 
     anotherOne: 
         deepDeepValue: !faker ["name.lastName"]
-nameInFile: !faker ["name.firstName", "global"]
+nameInFile: !faker ["name.firstName", "file"]

--- a/fixtures/fixture-with-faker.data.yaml
+++ b/fixtures/fixture-with-faker.data.yaml
@@ -1,0 +1,7 @@
+test: This is a test
+name: !faker ["name.firstName", "global"]
+number: !faker ["random.number"]
+some: 
+    anotherOne: 
+        deepDeepValue: !faker ["name.lastName"]
+nameInFile: !faker ["name.firstName", "global"]

--- a/fixtures/fixture.data.yaml
+++ b/fixtures/fixture.data.yaml
@@ -1,0 +1,2 @@
+test: This is a test
+value: !!js/function 'function () { return 123;}'

--- a/fixtures/fixture.data.yaml
+++ b/fixtures/fixture.data.yaml
@@ -1,2 +1,0 @@
-test: This is a test
-value: !!js/function 'function () { return 123;}'

--- a/fixtures/fixture.spec.yaml
+++ b/fixtures/fixture.spec.yaml
@@ -4,7 +4,7 @@ apiCalls:
     header:
       Content-Type: application/json
     data:
-      email: !faker ["internet.email"]
+      email: !faker "internet.email"
       password: !faker ["internet.password", "file"]
     expect:
       status: 200

--- a/fixtures/fixture.spec.yaml
+++ b/fixtures/fixture.spec.yaml
@@ -1,0 +1,24 @@
+apiCalls:
+  - name: Login - success
+    call: post_users_login
+    header:
+      Content-Type: application/json
+    data:
+      email: !faker ["internet.email"]
+      password: !faker ["internet.password", "file"]
+    expect:
+      status: 200
+      json:
+        - user.status: ENABLED
+    save:
+      userResponse: json
+
+
+tests:
+  - name: Checking login response
+    expects:
+      - userResponse.message: to.be User logged Successfully
+
+  - name: User information exist
+    expects:
+      - userResponse: to.have.key user

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "colors": "^1.3.3",
     "commander": "^2.19.0",
     "expect.js": "^0.3.1",
+    "faker": "^4.1.0",
     "js-yaml": "^3.13.1",
     "jsonpath": "^1.0.0",
     "klaw-sync": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "colors": "^1.3.3",
     "commander": "^2.19.0",
     "expect.js": "^0.3.1",
+    "faker": "^4.1.0",
     "js-yaml": "^3.13.1",
     "jsonpath": "^1.0.0",
     "klaw-sync": "^6.0.0",

--- a/specs/apiCall.spec.js
+++ b/specs/apiCall.spec.js
@@ -60,6 +60,8 @@ describe('apiCall', () => {
       const apiCall = first(apiCallConfig.apiCalls)
       const body = apiCall.data
       expect(body.email).to.be.a('string')
+      expect(body.email).not.to.have.string('!faker')
+
       expect(body.password).not.to.be.a('string')
     })
   })

--- a/specs/apiCall.spec.js
+++ b/specs/apiCall.spec.js
@@ -1,0 +1,67 @@
+const {
+  expect,
+} = require('chai')
+
+const { first } = require('lodash')
+
+const ApiPort = require('../src/apiPort.js')
+const ApiCall = require('../src/apiCall.js')
+
+describe('apiCall', () => {
+  let apiPort;
+
+  before(() => {
+    process.env.TEST_DATA_PATH = './fixtures'
+    process.env.API_TESTS_PATH = './'
+    process.env.OPENAPI_PATH = './fixtures/api-docs.json'
+    process.env.SHARED_TEST_DATA = './openapitest/fixtures'
+    process.env.CD = '../'
+    process.env.API_SERVER_URL = 'http://localhost:8080'
+    apiPort = new ApiPort()
+    apiPort.init()
+  })
+
+  describe('init', () => {
+    it('Should load file property', () => {
+      const apiCallConfig = new ApiCall('./fixtures/fixture.spec.yaml', apiPort);
+      const apiCalls = first(apiCallConfig.apiCalls)
+      const test = first(apiCallConfig.tests)
+
+      expect(apiCalls).to.deep.include({
+        name: 'Login - success',
+        call: 'post_users_login',
+        header: {
+          'Content-Type': 'application/json',
+        },
+        expect: {
+          status: 200,
+          json: [{
+            'user.status': 'ENABLED',
+          }],
+        },
+        save: {
+          userResponse: 'json',
+        },
+      })
+
+      expect(test).to.deep.include({
+        name: 'Checking login response',
+        expects: [
+          {
+            'userResponse.message': 'to.be User logged Successfully',
+          },
+        ],
+      })
+    })
+
+
+    it('Should evaluate global fake data', () => {
+      const apiCallConfig = new ApiCall('./fixtures/fixture.spec.yaml', apiPort);
+      const apiCall = first(apiCallConfig.apiCalls)
+      const body = apiCall.data
+      expect(body.email).to.be.a('string')
+      expect(body.password).not.to.be.a('string')
+    })
+
+  })
+})

--- a/specs/apiCall.spec.js
+++ b/specs/apiCall.spec.js
@@ -62,6 +62,5 @@ describe('apiCall', () => {
       expect(body.email).to.be.a('string')
       expect(body.password).not.to.be.a('string')
     })
-
   })
 })

--- a/specs/apiPort.spec.js
+++ b/specs/apiPort.spec.js
@@ -29,6 +29,7 @@ describe('apiPort', () => {
       expect(data.name).to.be.a('string')
       expect(parseInt(data.number, 10)).to.be.a('number')
       expect(data).have.nested.property('some.anotherOne.deepDeepValue').and.to.be.a('string')
+      expect(data).have.nested.property('nameInFile').and.not.to.be.a('string')
     })
   })
 

--- a/specs/apiPort.spec.js
+++ b/specs/apiPort.spec.js
@@ -21,7 +21,17 @@ describe('apiPort', () => {
         value: 123,
       })
     })
+
+    it('Should resolve faker values', () => {
+      const apiPort = new ApiPort()
+      apiPort.init()
+      const data = apiPort.getDataFromFile('fixture-with-faker')
+      expect(data.name).to.be.a('string')
+      expect(parseInt(data.number, 10)).to.be.a('number')
+      expect(data).have.nested.property('some.anotherOne.deepDeepValue').and.to.be.a('string')
+    })
   })
+
 
   describe('set', () => {
     it('should set a value and be able to get it', () => {
@@ -102,6 +112,7 @@ describe('apiPort', () => {
       apiPort.expectationOn(json, { deployment: 'to.be.equal hello' })
       apiPort.expectationOn(json, { isUndefined: 'to.not.be.ok' })
     })
+
     it('should throw expected exceptions properly', () => {
       const apiPort = new ApiPort()
       const json = {

--- a/specs/faker.spec.js
+++ b/specs/faker.spec.js
@@ -16,8 +16,10 @@ describe('FakerClass', () => {
     expect(faker.value('global')).not.to.be.a('string')
 
     expect(faker.value('file')).to.be.a('string')
+    expect(faker.value('file')).not.to.have.string('!faker')
 
     expect(faker.value('test')).to.be.a('string')
+    expect(faker.value('test')).not.to.have.string('!faker')
   })
 
   it('should evaluate not evaluate global or file scope if the FakerClass has a test scope', () => {
@@ -28,6 +30,7 @@ describe('FakerClass', () => {
     expect(faker.value('file')).not.to.be.a('string')
 
     expect(faker.value('test')).to.be.a('string')
+    expect(faker.value('test')).not.to.have.string('!faker')
   })
 
   it('should thrown an error if the scope is not valid', () => {

--- a/specs/faker.spec.js
+++ b/specs/faker.spec.js
@@ -1,0 +1,42 @@
+const {
+  expect,
+} = require('chai')
+const { FakerClass, fakerScopes } = require('../src/customTypes/faker.js')
+
+describe('FakerClass', () => {
+  it('should evaluate faker API', () => {
+    const faker = new FakerClass('name.lastName', 'global')
+    expect(faker.value('global')).to.be.a('string')
+    expect(faker.value('global')).to.not.contains('!faker')
+  })
+
+  it('should evaluate not evaluate global scope if the FakerClass has a file scope', () => {
+    const faker = new FakerClass('name.lastName', fakerScopes.file)
+
+    expect(faker.value('global')).not.to.be.a('string')
+
+    expect(faker.value('file')).to.be.a('string')
+
+    expect(faker.value('test')).to.be.a('string')
+  })
+
+  it('should evaluate not evaluate global or file scope if the FakerClass has a test scope', () => {
+    const faker = new FakerClass('name.lastName', fakerScopes.test)
+
+    expect(faker.value('global')).not.to.be.a('string')
+
+    expect(faker.value('file')).not.to.be.a('string')
+
+    expect(faker.value('test')).to.be.a('string')
+  })
+
+  it('should thrown an error if the scope is not valid', () => {
+    const faker = new FakerClass('name.lastName', fakerScopes.test)
+
+    expect(() => faker.value('jose')).to.throw('Error: jose is not a valid Faker scope. Try one of global,file,test')
+  })
+
+  it('should thrown an error if the scope is not valid in the constructor', () => {
+    expect(() => new FakerClass('name.lastName', 'mary')).to.throw('Error: mary is not a valid Faker scope. Try one of global,file,test')
+  })
+})

--- a/specs/util.spec.js
+++ b/specs/util.spec.js
@@ -77,41 +77,4 @@ describe('util', () => {
       expect(() => util.loadFile('./there-no-this-file')).to.throw('Could not load the file: "./there-no-this-file". One of the next files must exists: ./there-no-this-file,./there-no-this-file.js,./there-no-this-file.yaml,./there-no-this-file.yml');
     });
   });
-
-  describe('FakerClass', () => {
-    it('should evaluate faker API', () => {
-      const faker = new util.FakerClass('name.lastName', 'global')
-      expect(faker.value('global')).to.be.a('string')
-    })
-
-    it('should evaluate not evaluate global scope if the FakerClass has a file scope', () => {
-      const faker = new util.FakerClass('name.lastName', util.fakerScopes.file)
-
-      expect(faker.value('global')).not.to.be.a('string')
-
-      expect(faker.value('file')).to.be.a('string')
-
-      expect(faker.value('test')).to.be.a('string')
-    })
-
-    it('should evaluate not evaluate global or file scope if the FakerClass has a test scope', () => {
-      const faker = new util.FakerClass('name.lastName', util.fakerScopes.test)
-
-      expect(faker.value('global')).not.to.be.a('string')
-
-      expect(faker.value('file')).not.to.be.a('string')
-
-      expect(faker.value('test')).to.be.a('string')
-    })
-
-    it('should thrown an error if the scope is not valid', () => {
-      const faker = new util.FakerClass('name.lastName', util.fakerScopes.test)
-
-      expect(() => faker.value('jose')).to.throw('Error: jose is not a valid Faker scope. Try one of global,file,test')
-    })
-
-    it('should thrown an error if the scope is not valid in the constructor', () => {
-      expect(() => new util.FakerClass('name.lastName', 'mary')).to.throw('Error: mary is not a valid Faker scope. Try one of global,file,test')
-    })
-  })
 })

--- a/specs/util.spec.js
+++ b/specs/util.spec.js
@@ -49,7 +49,6 @@ describe('util', () => {
     })
   })
 
-<<<<<<< HEAD
   describe('loadFile', () => {
     it('Should resolve the files and parse yaml into to an object with extention missing', () => {
       const data = util.loadFile('./fixtures/fixture.data')
@@ -79,12 +78,40 @@ describe('util', () => {
     });
   });
 
-=======
->>>>>>> ac14cc6af67da7167e8be64e647724ffe82dcd6d
   describe('FakerClass', () => {
     it('should evaluate faker API', () => {
       const faker = new util.FakerClass('name.lastName', 'global')
       expect(faker.value('global')).to.be.a('string')
+    })
+
+    it('should evaluate not evaluate global scope if the FakerClass has a file scope', () => {
+      const faker = new util.FakerClass('name.lastName', util.fakerScopes.file)
+
+      expect(faker.value('global')).not.to.be.a('string')
+
+      expect(faker.value('file')).to.be.a('string')
+
+      expect(faker.value('test')).to.be.a('string')
+    })
+
+    it('should evaluate not evaluate global or file scope if the FakerClass has a test scope', () => {
+      const faker = new util.FakerClass('name.lastName', util.fakerScopes.test)
+
+      expect(faker.value('global')).not.to.be.a('string')
+
+      expect(faker.value('file')).not.to.be.a('string')
+
+      expect(faker.value('test')).to.be.a('string')
+    })
+
+    it('should thrown an error if the scope is not valid', () => {
+      const faker = new util.FakerClass('name.lastName', util.fakerScopes.test)
+
+      expect(() => faker.value('jose')).to.throw('Error: jose is not a valid Faker scope. Try one of global,file,test')
+    })
+
+    it('should thrown an error if the scope is not valid in the constructor', () => {
+      expect(() => new util.FakerClass('name.lastName', 'mary')).to.throw('Error: mary is not a valid Faker scope. Try one of global,file,test')
     })
   })
 })

--- a/specs/util.spec.js
+++ b/specs/util.spec.js
@@ -76,5 +76,12 @@ describe('util', () => {
     it('should thrown an error if the file does not exists', () => {
       expect(() => util.loadFile('./there-no-this-file')).to.throw('Could not load the file: "./there-no-this-file". One of the next files must exists: ./there-no-this-file,./there-no-this-file.js,./there-no-this-file.yaml,./there-no-this-file.yml');
     });
+  });
+
+  describe('FakerClass', () => {
+    it('should evaluate faker API', () => {
+      const faker = new util.FakerClass('name.lastName', 'global')
+      expect(faker.value('global')).to.be.a('string')
+    })
   })
 })

--- a/specs/util.spec.js
+++ b/specs/util.spec.js
@@ -44,6 +44,10 @@ describe('util', () => {
       expect(() => util.loadYamlFile('./fixtures/fixture-with-faker-invalid.data.yaml')).to.throw('cannot resolve a node with !<!faker> explicit tag at line 3, column 1');
     });
 
+    it('should thrown an error if the file is invalid faker scope', () => {
+      expect(() => util.loadYamlFile('./fixtures/fixture-with-faker-invalid-scope.data.yaml')).to.throw('Error parsing the file ./fixtures/fixture-with-faker-invalid-scope.data.yaml: Error: wrong-scope is not a valid Faker scope. Try one of global,file,test');
+    });
+
 
     it('Should resolve the files and parse yaml into to an object', () => {
       const data = util.loadYamlFile('./fixtures/fixture.data.yaml')

--- a/specs/util.spec.js
+++ b/specs/util.spec.js
@@ -47,4 +47,11 @@ describe('util', () => {
       })
     })
   })
+
+  describe('FakerClass', () => {
+    it('should evaluate faker API', () => {
+      const faker = new util.FakerClass('name.lastName', 'global')
+      expect(faker.value('global')).to.be.a('string')
+    })
+  })
 })

--- a/specs/util.spec.js
+++ b/specs/util.spec.js
@@ -40,6 +40,11 @@ describe('util', () => {
       expect(() => util.loadYamlFile('./fixtures/fixture-invalid.data.yaml')).to.throw(/Error parsing the file .\/fixtures\/fixture-invalid.data.yaml/);
     });
 
+    it('should thrown an error if the file is invalid faker', () => {
+      expect(() => util.loadYamlFile('./fixtures/fixture-with-faker-invalid.data.yaml')).to.throw('cannot resolve a node with !<!faker> explicit tag at line 3, column 1');
+    });
+
+
     it('Should resolve the files and parse yaml into to an object', () => {
       const data = util.loadYamlFile('./fixtures/fixture.data.yaml')
       expect(data).to.deep.equal({

--- a/src/apiCall.js
+++ b/src/apiCall.js
@@ -23,7 +23,6 @@ function getItFunction(req) {
 
 module.exports = function apiCall(file, apiPort) {
   const config = init(file)
-
   const openSpec = apiPort.get('OPENAPI_SPEC')
   const operations = apiPort.get('OPENAPI_OPERATIONS')
 
@@ -182,6 +181,7 @@ module.exports = function apiCall(file, apiPort) {
       }
     })
   })
+  return config
 }
 
 function init(file) {

--- a/src/apiCall.js
+++ b/src/apiCall.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 const objectPath = require('object-path')
 const { expect } = require('chai')
 
-const { loadYamlFile } = require('./util.js')
+const { loadYamlFile, evaluateFaker, fakerScopes } = require('./util.js')
 const SuperClient = require('./superClient')
 
 const processedExpectations = ['status', 'json', 'headers', 'error']
@@ -42,10 +42,16 @@ module.exports = function apiCall(file, apiPort) {
     })
   })
 
-  config.apiCalls.swagger.forEach((req) => {
-    const itMethod = getItFunction(req);
+  const fileEvaluator = _.ary(_.partialRight(evaluateFaker, fakerScopes.file), 1);
 
-    itMethod(req.name || req.call, async function itFn() {
+  const swaggerParserd = config.apiCalls.swagger
+    .map(fileEvaluator)
+
+  swaggerParserd.forEach((_req) => {
+    const itMethod = getItFunction(_req);
+
+    itMethod(_req.name || _req.call, async function itFn() {
+      const req = evaluateFaker(_req, fakerScopes.test)
       this.timeout(apiPort.get('TIMEOUT'))
 
       if (!operationIds[req.call]) {
@@ -81,6 +87,7 @@ module.exports = function apiCall(file, apiPort) {
       const save = req.save || {}
 
       try {
+        allReqData = evaluateFaker(allReqData, fakerScopes.test)
         if (req.before && _.isFunction(req.before)) {
           req.before.call(req, {
             apiPort,

--- a/src/apiCall.js
+++ b/src/apiCall.js
@@ -2,7 +2,8 @@ const _ = require('lodash')
 const objectPath = require('object-path')
 const { expect } = require('chai')
 
-const { loadYamlFile, evaluateFaker, fakerScopes } = require('./util.js')
+const { loadYamlFile } = require('./util.js')
+const { evaluateFaker, fakerScopes } = require('./customTypes/faker.js')
 const SuperClient = require('./superClient')
 
 const processedExpectations = ['status', 'json', 'headers', 'error']

--- a/src/apiCall.js
+++ b/src/apiCall.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
 const objectPath = require('object-path')
-const { expect } = require('chai');
+const { expect } = require('chai')
 
 const { loadYamlFile } = require('./util.js')
 const SuperClient = require('./superClient')

--- a/src/apiPort.js
+++ b/src/apiPort.js
@@ -4,7 +4,7 @@ const expect = require('expect.js')
 const fs = require('fs')
 const path = require('path')
 const klawSync = require('klaw-sync')
-const { loadFile } = require('./util.js')
+const { loadFile, YamlParsingError } = require('./util.js')
 
 const currentDir = process.cwd()
 
@@ -244,6 +244,9 @@ class ApiPort {
           } catch (e) {
             delete this.apiPort.$file[fileName]
             // Ignored here if not found will re-throw the error in the end of this loop
+            if (e instanceof YamlParsingError) {
+              throw e
+            }
           }
         }
       }

--- a/src/customTypes/faker.js
+++ b/src/customTypes/faker.js
@@ -1,0 +1,88 @@
+const faker = require('faker')
+const {
+  isFunction, includes, mapValues, partialRight, isArray, ary, isObject,
+} = require('lodash')
+const YAML = require('js-yaml')
+
+const GLOBAL = 'global'
+const FILE = 'file'
+const TEST = 'test'
+
+const SCOPE_HIERARCHY = {
+  [GLOBAL]: [GLOBAL],
+  [FILE]: [FILE, GLOBAL],
+  [TEST]: [TEST, FILE, GLOBAL],
+};
+
+function getScopesToEvaluate(scope) {
+  const scopesToEvaluate = SCOPE_HIERARCHY[scope]
+  if (!scopesToEvaluate) {
+    throw new Error(`Error: ${scope} is not a valid Faker scope. Try one of ${Object.keys(SCOPE_HIERARCHY).join(',')}`)
+  }
+  return scopesToEvaluate
+}
+
+const validateScope = getScopesToEvaluate // Sugar function to be used in FakerClass constructor
+
+function FakerClass(fakerInstruction, scope = GLOBAL) {
+  this.fakerInstruction = fakerInstruction
+  this.scope = scope
+  validateScope(scope)
+}
+
+FakerClass.prototype.value = function value(scope = GLOBAL) {
+  const scopesToEvaluate = getScopesToEvaluate(scope)
+  return includes(scopesToEvaluate, this.scope) ? faker.fake(`{{${this.fakerInstruction}}}`) : this
+}
+
+const FakerClassType = new YAML.Type('!faker', {
+  kind: 'sequence',
+  resolve(data) {
+    return data !== null && data.length > 0
+  },
+
+  construct(data) {
+    return new FakerClass(data[0], data[1])
+  },
+
+  instanceOf: FakerClass,
+
+  represent(obj) {
+    return [obj.fakerInstruction, obj.scope];
+  },
+});
+
+
+const FAKER_SCHEMA = YAML.Schema.create([FakerClassType])
+
+function isFaker(data) {
+  return (data instanceof FakerClass) && data.value && isFunction(data.value)
+}
+
+function evaluateFaker(data, scope) {
+  if (isFaker(data)) {
+    const resulvedValue = data.value(scope)
+    return resulvedValue
+  }
+
+  if (isArray(data)) {
+    return data.map(ary(partialRight(evaluateFaker, scope), 1))
+  }
+
+  if (isObject(data)) {
+    return mapValues(data, value => (isObject(value) ? evaluateFaker(value, scope) : value))
+  }
+  return data
+}
+
+module.exports = {
+  isFaker,
+  FakerClass,
+  evaluateFaker,
+  fakerScopes: {
+    global: GLOBAL,
+    file: FILE,
+    test: TEST,
+  },
+  FAKER_SCHEMA,
+}

--- a/src/util.js
+++ b/src/util.js
@@ -1,88 +1,23 @@
 const fs = require('fs')
 const YAML = require('js-yaml')
-const faker = require('faker')
 const {
-  isFunction, includes, set, isObject, find, endsWith, mapValues, partialRight, isArray, ary,
+  isFunction, includes, set, isObject, find, endsWith,
 } = require('lodash')
-
-const GLOBAL = 'global'
-const FILE = 'file'
-const TEST = 'test'
-
-const SCOPE_HIERARCHY = {
-  [GLOBAL]: [GLOBAL],
-  [FILE]: [FILE, GLOBAL],
-  [TEST]: [TEST, FILE, GLOBAL],
-};
+const {
+  isFaker,
+  evaluateFaker,
+  fakerScopes,
+  FAKER_SCHEMA,
+} = require('./customTypes/faker.js')
 
 const isObj = value => isObject(value) && !isFunction(value)
 
 const KEYS_TO_IGNORE = ['before', 'after']
 
-function getScopesToEvaluate(scope) {
-  const scopesToEvaluate = SCOPE_HIERARCHY[scope]
-  if (!scopesToEvaluate) {
-    throw new Error(`Error: ${scope} is not a valid Faker scope. Try one of ${Object.keys(SCOPE_HIERARCHY).join(',')}`)
-  }
-  return scopesToEvaluate
-}
-
-const validateScope = getScopesToEvaluate // Sugar function to be used in FakerClass constructor
-
-function FakerClass(fakerInstruction, scope = GLOBAL) {
-  this.fakerInstruction = fakerInstruction
-  this.scope = scope
-  validateScope(scope)
-}
-
-FakerClass.prototype.value = function value(scope = GLOBAL) {
-  const scopesToEvaluate = getScopesToEvaluate(scope)
-  return includes(scopesToEvaluate, this.scope) ? faker.fake(`{{${this.fakerInstruction}}}`) : this
-}
-
-const FakerClassType = new YAML.Type('!faker', {
-  kind: 'sequence',
-  resolve(data) {
-    return data !== null && data.length > 0
-  },
-
-  construct(data) {
-    return new FakerClass(data[0], data[1])
-  },
-
-  instanceOf: FakerClass,
-
-  represent(obj) {
-    return [obj.fakerInstruction, obj.scope];
-  },
-});
-
-
-const CUSTUM_SCHEMA = YAML.Schema.create([FakerClassType])
-
-function isFaker(data) {
-  return (data instanceof FakerClass) && data.value && isFunction(data.value)
-}
-
-function evaluateFaker(data, scope) {
-  if (isFaker(data)) {
-    const resulvedValue = data.value(scope)
-    return resulvedValue
-  }
-
-  if (isArray(data)) {
-    return data.map(ary(partialRight(evaluateFaker, scope), 1))
-  }
-
-  if (isObj(data)) {
-    return mapValues(data, value => (isObj(value) ? evaluateFaker(value, scope) : value))
-  }
-  return data
-}
 
 function evaluateData(data) {
   if (isFaker(data)) {
-    return evaluateFaker(data, GLOBAL)
+    return evaluateFaker(data, fakerScopes.global)
   }
   const keys = Object.keys(data)
   return keys.reduce((obj, key) => {
@@ -97,7 +32,7 @@ function evaluateData(data) {
 function loadYamlFile(filePath) {
   const fileText = fs.readFileSync(filePath, 'utf8')
   try {
-    const parsedData = YAML.load(fileText, { schema: CUSTUM_SCHEMA })
+    const parsedData = YAML.load(fileText, { schema: FAKER_SCHEMA })
     const yamlDataEvaluated = evaluateData(parsedData)
     return yamlDataEvaluated
   } catch (e) {
@@ -128,11 +63,4 @@ module.exports = {
   loadYamlFile,
   evaluateData,
   loadFile,
-  FakerClass,
-  evaluateFaker,
-  fakerScopes: {
-    global: GLOBAL,
-    file: FILE,
-    test: TEST,
-  },
 }

--- a/src/util.js
+++ b/src/util.js
@@ -38,8 +38,12 @@ FakerClass.prototype.value = function value(scope) {
 
 const CUSTUM_SCHEMA = YAML.Schema.create([FakerClassType])
 
+function isFaker(data) {
+  return (data instanceof FakerClass) && data.value && isFunction(data.value)
+}
+
 function evaluateFaker(data, scope) {
-  if (data.value && isFunction(data.value)) {
+  if (isFaker(data)) {
     const resulvedValue = data.value(scope)
     return resulvedValue
   }
@@ -47,7 +51,7 @@ function evaluateFaker(data, scope) {
 }
 
 function evaluateData(data) {
-  if (data.value && isFunction(data.value)) {
+  if (isFaker(data)) {
     return evaluateFaker(data, 'global')
   }
   const keys = Object.keys(data)

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,8 @@
 const fs = require('fs')
 const YAML = require('js-yaml')
+const faker = require('faker')
 const {
-  isFunction, includes, set, isObject, find, endsWith,
+  isFunction, includes, set, isObject, find, endsWith, mapValues,
 } = require('lodash')
 
 const isObj = value => isObject(value) && !isFunction(value)
@@ -9,7 +10,46 @@ const isObj = value => isObject(value) && !isFunction(value)
 const KEYS_TO_IGNORE = ['before', 'after']
 
 
+function FakerClass(fakerInstruction, scope = 'global') {
+  this.fakerInstruction = fakerInstruction
+  this.scope = scope
+}
+
+const FakerClassType = new YAML.Type('!faker', {
+  kind: 'sequence',
+  resolve(data) {
+    return data !== null && data.length > 0
+  },
+
+  construct(data) {
+    return new FakerClass(data[0], data[1])
+  },
+
+  instanceOf: FakerClass,
+
+  represent(obj) {
+    return [obj.fakerInstruction, obj.scope];
+  },
+});
+
+FakerClass.prototype.value = function value(scope) {
+  return scope === this.scope ? faker.fake(`{{${this.fakerInstruction}}}`) : this
+}
+
+const CUSTUM_SCHEMA = YAML.Schema.create([FakerClassType])
+
+function evaluateFaker(data, scope) {
+  if (data.value && isFunction(data.value)) {
+    const resulvedValue = data.value(scope)
+    return resulvedValue
+  }
+  return mapValues(data, value => (isObj(value) ? evaluateFaker(value) : value))
+}
+
 function evaluateData(data) {
+  if (data.value && isFunction(data.value)) {
+    return evaluateFaker(data, 'global')
+  }
   const keys = Object.keys(data)
   return keys.reduce((obj, key) => {
     const value = data[key]
@@ -23,7 +63,7 @@ function evaluateData(data) {
 function loadYamlFile(filePath) {
   const fileText = fs.readFileSync(filePath, 'utf8')
   try {
-    const parsedData = YAML.load(fileText)
+    const parsedData = YAML.load(fileText, { schema: CUSTUM_SCHEMA })
     const yamlDataEvaluated = evaluateData(parsedData)
     return yamlDataEvaluated
   } catch (e) {
@@ -54,4 +94,5 @@ module.exports = {
   loadYamlFile,
   evaluateData,
   loadFile,
+  FakerClass,
 }

--- a/src/util.js
+++ b/src/util.js
@@ -2,15 +2,19 @@ const fs = require('fs')
 const YAML = require('js-yaml')
 const faker = require('faker')
 const {
-  isFunction, includes, set, isObject, find, endsWith, mapValues,
+  isFunction, includes, set, isObject, find, endsWith, mapValues, partialRight, isArray, ary,
 } = require('lodash')
+
+const GLOBAL = 'global'
+const FILE = 'file'
+const TEST = 'test'
 
 const isObj = value => isObject(value) && !isFunction(value)
 
 const KEYS_TO_IGNORE = ['before', 'after']
 
 
-function FakerClass(fakerInstruction, scope = 'global') {
+function FakerClass(fakerInstruction, scope = GLOBAL) {
   this.fakerInstruction = fakerInstruction
   this.scope = scope
 }
@@ -47,12 +51,20 @@ function evaluateFaker(data, scope) {
     const resulvedValue = data.value(scope)
     return resulvedValue
   }
-  return mapValues(data, value => (isObj(value) ? evaluateFaker(value) : value))
+
+  if (isArray(data)) {
+    return data.map(ary(partialRight(evaluateFaker, scope), 1))
+  }
+
+  if (isObj(data)) {
+    return mapValues(data, value => (isObj(value) ? evaluateFaker(value, scope) : value))
+  }
+  return data
 }
 
 function evaluateData(data) {
   if (isFaker(data)) {
-    return evaluateFaker(data, 'global')
+    return evaluateFaker(data, GLOBAL)
   }
   const keys = Object.keys(data)
   return keys.reduce((obj, key) => {
@@ -99,4 +111,10 @@ module.exports = {
   evaluateData,
   loadFile,
   FakerClass,
+  evaluateFaker,
+  fakerScopes: {
+    global: GLOBAL,
+    file: FILE,
+    test: TEST,
+  },
 }

--- a/src/util.js
+++ b/src/util.js
@@ -14,6 +14,7 @@ const isObj = value => isObject(value) && !isFunction(value)
 
 const KEYS_TO_IGNORE = ['before', 'after']
 
+class YamlParsingError extends Error {}
 
 function evaluateData(data) {
   if (isFaker(data)) {
@@ -36,7 +37,7 @@ function loadYamlFile(filePath) {
     const yamlDataEvaluated = evaluateData(parsedData)
     return yamlDataEvaluated
   } catch (e) {
-    throw new Error(`Error parsing the file ${filePath}: ${e.message}`)
+    throw new YamlParsingError(`Error parsing the file ${filePath}: ${e.message}`)
   }
 }
 
@@ -63,4 +64,5 @@ module.exports = {
   loadYamlFile,
   evaluateData,
   loadFile,
+  YamlParsingError,
 }


### PR DESCRIPTION
The approach I used to create this was to add a new type to YAML and transform the type in a resolved value when it should.

## How it works

Here we evaluate the `global` scope: https://github.com/mateusfreira/openapitest/blob/74d1050d37eb9db19e764c262fe3559a93bbb1c9/src/util.js#L68

Here evaluate the `file` scope: https://github.com/mateusfreira/openapitest/blob/74d1050d37eb9db19e764c262fe3559a93bbb1c9/src/apiCall.js#L44

And here we evaluate the `test` scope: 
Here for the specs: https://github.com/mateusfreira/openapitest/blob/74d1050d37eb9db19e764c262fe3559a93bbb1c9/src/apiCall.js#L53


And here for the data coming from file: 
https://github.com/mateusfreira/openapitest/blob/74d1050d37eb9db19e764c262fe3559a93bbb1c9/src/apiCall.js#L89


## How it tested

Here I added some tests to the FakerClass: 
https://github.com/mateusfreira/openapitest/blob/74d1050d37eb9db19e764c262fe3559a93bbb1c9/specs/util.spec.js#L81

Here the tests for the file load: 
https://github.com/mateusfreira/openapitest/blob/74d1050d37eb9db19e764c262fe3559a93bbb1c9/specs/apiPort.spec.js#L25


I also added a few tests the API call:
https://github.com/mateusfreira/openapitest/blob/74d1050d37eb9db19e764c262fe3559a93bbb1c9/specs/apiCall.spec.js#L10

But did not intend to cover all class, the intention here was to start the tests for that class.

## How it was documented

Here I updated the `README.md` 

https://github.com/testbetter/openapitest/compare/master...mateusfreira:faker-js?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R505 and provided some example



## Bonus Issue fix
Here I also fix the issue #10 